### PR TITLE
fix hosted tool cache usage on windows

### DIFF
--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -114,7 +114,7 @@ jobs:
         shell: bash
 
   hostedtoolcache:
-    name: 'Validate if hostedtoolcache works as expected' 
+    name: 'Validate if hostedtoolcache works as expected'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -128,12 +128,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: ${{ matrix.cache }}
-          
+
       - name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }} (from hostedtoolcache)'
         uses: ./
         with:
           go-version: ${{ matrix.go }}
           cache: ${{ matrix.cache }}
-    
-    
-    

--- a/.github/workflows/windows-validation.yml
+++ b/.github/workflows/windows-validation.yml
@@ -105,10 +105,35 @@ jobs:
           fi
         shell: bash
 
-      - name: 'Drive D: should not have Go installation, cache: ${{ matrix.cache}}'
+      - name: 'Drive D: should not have Go installation, cache: ${{ matrix.cache }}'
         run: |
           if [ -e 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64' ];then
             echo 'D:\hostedtoolcache\windows\go\${{ needs.find-default-go.outputs.version }}\x64 should not exist for hosted version of go';
             exit 1
           fi
         shell: bash
+
+  hostedtoolcache:
+    name: 'Validate if hostedtoolcache works as expected' 
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        cache: [false]
+        go: [1.20.1]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }}'
+        uses: ./
+        with:
+          go-version: ${{ matrix.go }}
+          cache: ${{ matrix.cache }}
+          
+      - name: 'Setup ${{ matrix.go }}, cache: ${{ matrix.cache }} (from hostedtoolcache)'
+        uses: ./
+        with:
+          go-version: ${{ matrix.go }}
+          cache: ${{ matrix.cache }}
+    
+    
+    

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -61514,6 +61514,10 @@ function cacheWindowsDir(extPath, tool, version, arch) {
         fs_1.default.mkdirSync(path.dirname(defaultToolCacheDir), { recursive: true });
         fs_1.default.symlinkSync(actualToolCacheDir, defaultToolCacheDir, 'junction');
         core.info(`Created link ${defaultToolCacheDir} => ${actualToolCacheDir}`);
+        const actualToolCacheCompleteFile = `${actualToolCacheDir}.complete`;
+        const defaultToolCacheCompleteFile = `${defaultToolCacheDir}.complete`;
+        fs_1.default.symlinkSync(actualToolCacheCompleteFile, defaultToolCacheCompleteFile, 'file');
+        core.info(`Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`);
         // make outer code to continue using toolcache as if it were installed on c:
         // restore toolcache root to default drive c:
         process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -205,8 +205,14 @@ async function cacheWindowsDir(
 
   const actualToolCacheCompleteFile = `${actualToolCacheDir}.complete`;
   const defaultToolCacheCompleteFile = `${defaultToolCacheDir}.complete`;
-  fs.symlinkSync(actualToolCacheCompleteFile, defaultToolCacheCompleteFile, 'file');
-  core.info(`Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`);
+  fs.symlinkSync(
+    actualToolCacheCompleteFile,
+    defaultToolCacheCompleteFile,
+    'file'
+  );
+  core.info(
+    `Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`
+  );
 
   // make outer code to continue using toolcache as if it were installed on c:
   // restore toolcache root to default drive c:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -203,6 +203,11 @@ async function cacheWindowsDir(
   fs.symlinkSync(actualToolCacheDir, defaultToolCacheDir, 'junction');
   core.info(`Created link ${defaultToolCacheDir} => ${actualToolCacheDir}`);
 
+  const actualToolCacheCompleteFile = `${actualToolCacheDir}.complete`;
+  const defaultToolCacheCompleteFile = `${defaultToolCacheDir}.complete`;
+  fs.symlinkSync(actualToolCacheCompleteFile, defaultToolCacheCompleteFile, 'file');
+  core.info(`Created link ${defaultToolCacheCompleteFile} => ${actualToolCacheCompleteFile}`);
+
   // make outer code to continue using toolcache as if it were installed on c:
   // restore toolcache root to default drive c:
   process.env['RUNNER_TOOL_CACHE'] = defaultToolCacheRoot;


### PR DESCRIPTION
**Description:**
This change ensures that we symlink not only the tool directory but also the completion marker when adding `go` to the hosted tool cache on Windows.

**Related issue:**
Not raised, but without this change it is impossible to run the action twice with the same `go-version` input on Windows because the second run fails with errors related to files already existing.

**Testing:**
- 🔴 Example test run without the fix: https://github.com/galargh/setup-go/actions/runs/5843165063/job/15845040764
- 🟢 Example test run with the fix: https://github.com/galargh/setup-go/actions/runs/5843616834/job/15845918944

**Check list:**
- [x] Mark if documentation changes are required. (not required)
- [x] Mark if tests were added or updated to cover the changes.